### PR TITLE
Remove python lib detection which isn't used anywhere

### DIFF
--- a/src/aedifix/packages/python.py
+++ b/src/aedifix/packages/python.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING, Final
 
 from ..package import Package
 from ..util.argument_parser import ArgSpec, ConfigArgument
-from ..util.exception import UnsatisfiableConfigurationError
-from ..util.utility import find_active_python_version_and_path
 
 if TYPE_CHECKING:
     from ..manager import ConfigurationManager
@@ -26,53 +24,6 @@ class Python(Package):
         enables_package=True,
         primary=True,
     )
-
-    def __init__(self, manager: ConfigurationManager) -> None:
-        super().__init__(manager=manager)
-
-    def configure_lib_version_and_paths(self) -> None:
-        r"""Determine the Python library version and its location."""
-        try:
-            version, lib_path = find_active_python_version_and_path()
-        except (RuntimeError, FileNotFoundError) as excn:
-            if self.state.disabled():
-                # Not sure how we'd get here
-                msg = (
-                    "The Python package does not appear to be enabled, yet we "
-                    "are in the middle of configuring it. I'm not sure how we "
-                    "got here, this should not happen"
-                )
-                raise RuntimeError(msg) from excn
-            # Python is requested, now to determine whether the user did
-            # that or some other piece of the code
-            if self.state.explicitly_enabled():
-                # If the user wants python, but we cannot find/use it, then
-                # that's a hard error
-                msg = (
-                    f"{excn}. You have explicitly requested Python via "
-                    f"{self.With_Python.name} {self.cl_args.with_python.value}"
-                )
-                raise UnsatisfiableConfigurationError(msg) from excn
-            # Some other piece of code has set the cl_args to true
-            msg = (
-                f"{excn}. Some other package has implicitly enabled python"
-                " but could not locate active lib directories for it"
-            )
-            raise RuntimeError(msg) from excn
-
-        self.lib_version = version
-        self.lib_path = lib_path
-        self.log(
-            f"Python: found lib version: {version} and library path {lib_path}"
-        )
-
-    def configure(self) -> None:
-        r"""Configure Python."""
-        super().configure()
-        if not self.state.enabled():
-            return
-
-        self.log_execute_func(self.configure_lib_version_and_paths)
 
     def summarize(self) -> str:
         r"""Summarize configured Python.


### PR DESCRIPTION
The version detection code ended up tripping up on some more _esoteric_ linux installs, but I realized that we don't actually use it anywhere anymore. The only places it is read is in legate, and only for informational purposes. We can remove it 

cc @cryos 