### PR TITLE
Fixup CUDA architecture defaults to make them into a list

### DIFF
--- a/src/aedifix/packages/cuda.py
+++ b/src/aedifix/packages/cuda.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from argparse import Action, ArgumentParser, Namespace
 from pathlib import Path
@@ -55,7 +56,7 @@ class CudaArchAction(Action):
             # TODO(jfaibussowit): rubin?
         }
         arch = []
-        for sub_arch in in_arch.split(","):
+        for sub_arch in re.split(r"[;,]", in_arch):
             # support Turing, TURING, and, if the user is feeling spicy, tUrInG
             sub_arch_lo = sub_arch.strip().casefold()
             if not sub_arch_lo:
@@ -131,7 +132,9 @@ class CUDA(Package):
         spec=ArgSpec(
             dest="cuda_arch",
             required=False,
-            default=_guess_cuda_architecture(),
+            default=CudaArchAction.map_cuda_arch_names(
+                _guess_cuda_architecture()
+            ),
             action=CudaArchAction,
             help=(
                 "Specify the target GPU architecture. Available choices are: "

--- a/tests/packages/test_cuda.py
+++ b/tests/packages/test_cuda.py
@@ -18,6 +18,7 @@ ARCH_STR: tuple[tuple[str, list[str]], ...] = (
     ("turing,hopper", ["75", "90"]),
     ("volta,60,all-major", ["70", "60", "all-major"]),
     ("60,,80", ["60", "80"]),
+    ("50-real;120-real;121", ["50-real", "120-real", "121"]),
 )
 
 
@@ -33,6 +34,7 @@ class TestCUDA:
         ("env_var", "env_value", "expected"),
         [
             ("CUDAARCHS", "volta", "volta"),
+            ("CUDAARCHS", "volta;ampere", "volta;ampere"),
             ("CMAKE_CUDA_ARCHITECTURES", "75", "75"),
             ("", "", "all-major"),
         ],


### PR DESCRIPTION
I forgot that `CUDAARCHS` and `CMAKE_CUDA_ARCHITECTURES` could be styled after cmake lists (";"-separated strings), so add handling for this kind of list and apply it.