### PR TITLE
Pass cmake lists as proper lists instead of space-separated lists

### DIFF
--- a/src/aedifix/__init__.py
+++ b/src/aedifix/__init__.py
@@ -13,6 +13,7 @@ from .cmake import (
     CMakeList,
     CMakePath,
     CMaker,
+    CMakeSemiColonList,
     CMakeString,
 )
 from .main import basic_configure
@@ -28,6 +29,7 @@ __all__ = (
     "CMakeInt",
     "CMakeList",
     "CMakePath",
+    "CMakeSemiColonList",
     "CMakeString",
     "CMaker",
     "ConfigArgument",

--- a/src/aedifix/cmake/__init__.py
+++ b/src/aedifix/cmake/__init__.py
@@ -10,6 +10,7 @@ from .cmake_flags import (
     CMakeInt,
     CMakeList,
     CMakePath,
+    CMakeSemiColonList,
     CMakeString,
 )
 from .cmaker import CMaker
@@ -21,6 +22,7 @@ __all__ = (
     "CMakeInt",
     "CMakeList",
     "CMakePath",
+    "CMakeSemiColonList",
     "CMakeString",
     "CMaker",
 )

--- a/src/aedifix/cmake/cmake_flags.py
+++ b/src/aedifix/cmake/cmake_flags.py
@@ -237,13 +237,21 @@ class CMakeList(CMakeFlagBase):
             val = [v for v in (str(x).strip() for x in val) if v]
         return bool(val), val
 
-    def to_command_line(self, *, quote: bool = False) -> str:
+    def _cmake_list_to_command_line(self, *, quote: bool, sep: str) -> str:
         if (val := self.value) is None:
             val = []
-        val = ";".join(map(str, val))
+        val = sep.join(map(str, val))
         if quote:
             val = shlex_quote(val)
         return f"{self.prefix}{self.name}:{self.type}={val}"
+
+    def to_command_line(self, *, quote: bool = False) -> str:
+        return self._cmake_list_to_command_line(quote=quote, sep=" ")
+
+
+class CMakeSemiColonList(CMakeList):
+    def to_command_line(self, *, quote: bool = False) -> str:
+        return self._cmake_list_to_command_line(quote=quote, sep=";")
 
 
 class CMakeBool(CMakeFlagBase):

--- a/src/aedifix/cmake/cmake_flags.py
+++ b/src/aedifix/cmake/cmake_flags.py
@@ -240,7 +240,7 @@ class CMakeList(CMakeFlagBase):
     def to_command_line(self, *, quote: bool = False) -> str:
         if (val := self.value) is None:
             val = []
-        val = " ".join(map(str, val))
+        val = ";".join(map(str, val))
         if quote:
             val = shlex_quote(val)
         return f"{self.prefix}{self.name}:{self.type}={val}"

--- a/src/aedifix/packages/cuda.py
+++ b/src/aedifix/packages/cuda.py
@@ -10,7 +10,13 @@ from argparse import Action, ArgumentParser, Namespace
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-from ..cmake import CMAKE_VARIABLE, CMakeExecutable, CMakeList, CMakePath
+from ..cmake import (
+    CMAKE_VARIABLE,
+    CMakeExecutable,
+    CMakeList,
+    CMakePath,
+    CMakeSemiColonList,
+)
 from ..package import Package
 from ..util.argument_parser import ArgSpec, ConfigArgument
 
@@ -143,7 +149,9 @@ class CUDA(Package):
                 "'ampere' or 'hopper, blackwell'"
             ),
         ),
-        cmake_var=CMAKE_VARIABLE("CMAKE_CUDA_ARCHITECTURES", CMakeList),
+        cmake_var=CMAKE_VARIABLE(
+            "CMAKE_CUDA_ARCHITECTURES", CMakeSemiColonList
+        ),
     )
 
     def configure(self) -> None:

--- a/tests/cmake/test_cmake_flags.py
+++ b/tests/cmake/test_cmake_flags.py
@@ -81,7 +81,7 @@ class TestCMakeList:
         var = CMakeList("foo", value=value)
         cmd = var.to_command_line()
         assert isinstance(cmd, str)
-        expected_str = "" if val_copy is None else " ".join(map(str, val_copy))
+        expected_str = "" if val_copy is None else ";".join(map(str, val_copy))
         assert cmd == f"-Dfoo:STRING={expected_str}"
         assert var.value == val_copy
 


### PR DESCRIPTION
Add support for actual ;-separated CMake lists. The previous CMake lists passed flags as space-separated strings but kept internal storage as lists. The new ;-lists have the exact same internal storage (and rest of behavior), except they pass to cmake as ";" separated lists instead.