### PR TITLE
Move more default makefile variables to aedifix

### DIFF
--- a/src/aedifix/config.py
+++ b/src/aedifix/config.py
@@ -52,7 +52,12 @@ class ConfigFile(Configurable):
             config_file = config_file.with_suffix("")
 
         self._project_variables_file = self.project_arch_dir / config_file.name
-        self._default_subst = {"PYTHON_EXECUTABLE": sys.executable}
+        self._default_subst = {
+            "PYTHON_EXECUTABLE": sys.executable,
+            "PROJECT_NAME": manager.project_name_upper,
+            "PROJECT_DIR_NAME": manager.project_dir_name,
+            "PROJECT_ARCH_NAME": manager.project_arch_name,
+        }
 
     @property
     def template_file(self) -> Path:

--- a/src/aedifix/templates/variables.mk.in
+++ b/src/aedifix/templates/variables.mk.in
@@ -1,5 +1,101 @@
 # -*- mode: makefile-gmake -*-
+export SHELL ?= /usr/bin/env bash
+export AWK ?= awk
 export PYTHON ?= @AEDIFIX_PYTHON_EXECUTABLE@
 export CMAKE ?= @CMAKE_COMMAND@
-export CMAKE_BUILD_PARALLEL_LEVEL ?= @CMAKE_BUILD_PARALLEL_LEVEL@
 export CMAKE_GENERATOR ?= @CMAKE_GENERATOR@
+
+ifeq (4.2,$(firstword $(sort $(MAKE_VERSION) 4.2)))
+  # Since make 4.2:
+  #
+  # * The amount of parallelism can be determined by querying MAKEFLAGS, even when
+  # the job server is enabled (previously MAKEFLAGS would always contain only
+  # "-j", with no number, when job server was enabled).
+  #
+  # https://lists.gnu.org/archive/html/info-gnu/2016-05/msg00013.html
+  JOBS = $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
+else
+  JOBS =
+endif
+
+ifeq ($(strip $(JOBS)),)
+  # Parse the number of jobs from inspecting process list
+  MAKE_PID = $(shell echo $$PPID)
+  ifeq ($(strip $(MAKE_PID)),)
+    JOBS =
+  else
+    SED ?= sed
+    PS ?= ps
+    JOBS = $(strip $(shell $(PS) T | $(SED) -n 's%.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs\) *\([0-9][0-9]*\).*%\2%p'))
+  endif
+endif
+
+# Order of precedence is as follows:
+#
+# 1. -j N, if given by the user.
+# 2. CMAKE_BUILD_PARALLEL_LEVEL if defined in the environment.
+# 3. CMAKE_BUILD_PARALLEL_LEVEL from default by configure.
+ifeq ($(strip $(JOBS)),)
+  export CMAKE_BUILD_PARALLEL_LEVEL ?= @CMAKE_BUILD_PARALLEL_LEVEL@
+else
+  # use := to override any potential value of CMAKE_BUILD_PARALLEL_LEVEL
+  export CMAKE_BUILD_PARALLEL_LEVEL := $(JOBS)
+endif
+
+ifeq ($(strip $(V)),1)
+  export VERBOSE ?= 1
+else ifeq ($(strip $(V)),0)
+  export VERBOSE ?= 0
+endif
+
+AEDIFIX_CMAKE_DIR = $(@AEDIFIX_PROJECT_DIR_NAME@)/$(@AEDIFIX_PROJECT_ARCH_NAME@)/cmake_build
+
+export @AEDIFIX_PROJECT_NAME_UPPER@_BUILD_COMMAND ?= $(CMAKE) --build $(AEDIFIX_CMAKE_DIR)
+export @AEDIFIX_PROJECT_NAME_UPPER@_INSTALL_COMMAND ?= $(CMAKE) --install $(AEDIFIX_CMAKE_DIR)
+
+ifeq ($(strip $(PREFIX)),)
+export @AEDIFIX_PROJECT_NAME_UPPER@_INSTALL_PREFIX_COMMAND = # nothing
+else
+export @AEDIFIX_PROJECT_NAME_UPPER@_INSTALL_PREFIX_COMMAND = --prefix $(PREFIX)
+endif
+
+ifndef NINJA_STATUS
+SELECTED_COLOR = $(shell aedifix-select-arch-color $(@AEDIFIX_PROJECT_ARCH_NAME@))
+COLOR_ARCH = $(shell $(CMAKE) -E cmake_echo_color --switch=$(COLOR) --$(SELECTED_COLOR) $(@AEDIFIX_PROJECT_ARCH_NAME@))
+export NINJA_STATUS = [%f/%t] $(COLOR_ARCH): $(SOME_UNDEFINED_VARIABLE_TO_ADD_A_SPACE)
+endif
+
+## Print this help message.
+##
+.PHONY: help
+help:
+	@printf "Usage: make [MAKE_OPTIONS] [target] (see 'make --help' for MAKE_OPTIONS)\n"
+	@printf ""
+	@$(AWK) ' \
+    { \
+      if ($$0 ~ /^.PHONY: [a-zA-Z\-\0-9]+$$/) {	\
+        helpCommand = substr($$0, index($$0, ":") + 2);	\
+        if (helpMessage) { \
+          printf "\033[36m%-20s\033[0m %s\n", helpCommand, helpMessage; \
+          helpMessage = ""; \
+        } \
+      } else if ($$0 ~ /^[a-zA-Z\-\0-9.]+:/) { \
+        helpCommand = substr($$0, 0, index($$0, ":")); \
+        if (helpMessage) { \
+          printf "\033[36m%-20s\033[0m %s\n", helpCommand, helpMessage; \
+          helpMessage = ""; \
+        } \
+      } else if ($$0 ~ /^##/) { \
+        if (helpMessage) { \
+          helpMessage = helpMessage"\n                     "substr($$0, 3); \
+        } else { \
+          helpMessage = substr($$0, 3); \
+        } \
+      } else { \
+        if (helpMessage) { \
+          print "\n                     "helpMessage"\n"; \
+        } \
+        helpMessage = ""; \
+      } \
+    }' \
+    $(MAKEFILE_LIST)


### PR DESCRIPTION
This removes a lot of the common boilerplate that downstream projects might define.