### PR TITLE
Change SHELL assignment from `?=` to `=`.

### DIFF
--- a/src/aedifix/templates/variables.mk.in
+++ b/src/aedifix/templates/variables.mk.in
@@ -3,7 +3,7 @@
 # subsequent calls to configure (or reconfigure) will overwrite any changes.
 .NOTPARALLEL:
 
-export SHELL ?= /usr/bin/env bash
+export SHELL = /usr/bin/env bash
 export AWK ?= awk
 export PYTHON ?= @AEDIFIX_PYTHON_EXECUTABLE@
 export CMAKE ?= @CMAKE_COMMAND@


### PR DESCRIPTION
closes #21

`SHELL` is set by default, so `SHELL ?= xxx` has no effect.

Using `SHELL = /usr/bin/env bash` still has the desired effect of allowing the variable to be overwritten on the command line, e.g.

```
$ make cmd SHELL=zsh
```

will work.