### PR TITLE
Add default packages even if they are not reachable by main package

### DIFF
--- a/src/aedifix/manager.py
+++ b/src/aedifix/manager.py
@@ -482,7 +482,7 @@ class ConfigurationManager:
             "$ make",
         ]
 
-        from .packages.python import Python
+        from .packages import Python
 
         if self._get_package(Python).state.enabled():
             install_mess.extend(
@@ -507,8 +507,12 @@ class ConfigurationManager:
         # that are reachable starting from the main package dependencies.
         # ref: https://en.wikipedia.org/wiki/Depth-first_search#Pseudocode
 
+        from .packages import _all_default_packages
+
         seen: set[type[Package]] = set()
-        stack: list[type[Package]] = list(self._main_package.dependencies)
+        stack: list[type[Package]] = (
+            list(self._main_package.dependencies) + _all_default_packages()
+        )
 
         while stack:
             if (dep := stack.pop()) not in seen:

--- a/src/aedifix/packages/__init__.py
+++ b/src/aedifix/packages/__init__.py
@@ -2,3 +2,20 @@
 #                         All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..package.package import Package
+
+
+from .cmake import CMake
+from .cuda import CUDA
+from .python import Python
+
+
+def _all_default_packages() -> list[type[Package]]:
+    return [CMake, CUDA, Python]
+
+
+__all__ = ("CUDA", "CMake", "Python")

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -77,9 +77,12 @@ class TestConfigurationManager:
     def test_setup(self, AEDIFIX_PYTEST_ARCH: str) -> None:
         manager = ConfigurationManager((), DummyMainModule)
         orig_argv = deepcopy(manager.argv)
+        # Only the main module
         assert len(manager._modules) == 1
         manager.setup()
-        assert len(manager._modules) == 1
+        # 4 modules: The main module, and the default modules (currently only
+        # 3, CMake, CUDA, and Python).
+        assert len(manager._modules) == 4
         assert manager.argv == orig_argv
         assert (
             CLArg(


### PR DESCRIPTION
This fixes the problem of not exposing `--with-cudac` to cupynumeric by default.